### PR TITLE
Workaround for deprecated getScrollTop call. Fixes issue 36.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,32 @@
 {
   "name": "xatom-debug",
-  "version": "1.6.7",
+  "version": "1.6.11",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/atom": {
       "version": "0.0.36",
       "resolved": "https://registry.npmjs.org/@types/atom/-/atom-0.0.36.tgz",
       "integrity": "sha1-PXmG+oaIx/OqdD08ku0EZ0mAUGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/emissary": "0.0.29",
+        "@types/jquery": "3.2.9",
+        "@types/pathwatcher": "0.0.32",
+        "@types/q": "1.0.2",
+        "@types/space-pen": "0.0.28",
+        "@types/status-bar": "0.0.29",
+        "@types/text-buffer": "0.0.31"
+      }
     },
     "@types/emissary": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/emissary/-/emissary-0.0.29.tgz",
       "integrity": "sha1-86u3KkuuQh5l4/U548RV1XXza1E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/mixto": "0.0.28"
+      }
     },
     "@types/jquery": {
       "version": "3.2.9",
@@ -44,6 +57,10 @@
       "resolved": "https://registry.npmjs.org/@types/pathwatcher/-/pathwatcher-0.0.32.tgz",
       "integrity": "sha1-7asm+dRafyvFiFq4bZqh1G+G4AQ=",
       "dev": true,
+      "requires": {
+        "@types/node": "7.0.38",
+        "@types/q": "0.0.35"
+      },
       "dependencies": {
         "@types/q": {
           "version": "0.0.35",
@@ -63,34 +80,57 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/@types/space-pen/-/space-pen-0.0.28.tgz",
       "integrity": "sha512-tiRM024TSrGhrRQuDwKlDBCJGBxNNqur8wUhT1YXd0jzjuQq4XJn8qjO22MPhu5xRYDmTMdwxo0Z3IzQGPh9MQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/jquery": "3.2.9"
+      }
     },
     "@types/status-bar": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/status-bar/-/status-bar-0.0.29.tgz",
       "integrity": "sha512-vS5dbVUvjnLjgwXUthh8xhivkBh5OJVmWI+fcyws+7kHT/DG+kWrcxwXZO0gx+bLkk27pNXPWq7g8maWdHUsiQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/space-pen": "0.0.28",
+        "@types/text-buffer": "0.0.31"
+      }
     },
     "@types/text-buffer": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/text-buffer/-/text-buffer-0.0.31.tgz",
       "integrity": "sha512-0JTwpPOJG4TyunlEI7YSoq7dv//gLeodfzvqTSLXf3UOafG7TLx9wZwNv7ivysFQ2zQRmeUw+cuD2iGADmMOyQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/atom": "0.0.36",
+        "@types/emissary": "0.0.29"
+      }
     },
     "atom-package-deps": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.0.tgz",
-      "integrity": "sha1-u4PwqXZWO0i+TquJ58hjHD7shI0="
+      "integrity": "sha1-u4PwqXZWO0i+TquJ58hjHD7shI0=",
+      "requires": {
+        "atom-package-path": "1.1.0",
+        "sb-exec": "3.1.0",
+        "sb-fs": "3.0.0",
+        "semver": "5.3.0"
+      }
     },
     "atom-package-path": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/atom-package-path/-/atom-package-path-1.1.0.tgz",
-      "integrity": "sha1-tR/tvADnyM5SI9DYA9t6P09pYU8="
+      "integrity": "sha1-tR/tvADnyM5SI9DYA9t6P09pYU8=",
+      "requires": {
+        "sb-callsite": "1.1.2"
+      }
     },
     "consistent-env": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
-      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs="
+      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
+      "requires": {
+        "lodash.uniq": "4.5.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -115,12 +155,21 @@
     "sb-exec": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-3.1.0.tgz",
-      "integrity": "sha1-NMxlCIoRZ1Lrcg/d7/ZtLC6V7FE="
+      "integrity": "sha1-NMxlCIoRZ1Lrcg/d7/ZtLC6V7FE=",
+      "requires": {
+        "consistent-env": "1.3.1",
+        "lodash.uniq": "4.5.0",
+        "sb-npm-path": "2.0.0"
+      }
     },
     "sb-fs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-3.0.0.tgz",
-      "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g="
+      "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=",
+      "requires": {
+        "sb-promisify": "2.0.2",
+        "strip-bom-buf": "1.0.0"
+      }
     },
     "sb-memoize": {
       "version": "1.0.2",
@@ -130,7 +179,11 @@
     "sb-npm-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
-      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg="
+      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
+      "requires": {
+        "sb-memoize": "1.0.2",
+        "sb-promisify": "2.0.2"
+      }
     },
     "sb-promisify": {
       "version": "2.0.2",
@@ -145,7 +198,10 @@
     "strip-bom-buf": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI="
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "typescript": {
       "version": "2.4.1",

--- a/src/editor/editor-manager.ts
+++ b/src/editor/editor-manager.ts
@@ -257,10 +257,18 @@ export class EditorManager {
     var clientX = e.clientX
     var clientY = e.clientY
     let clientRect = lines.getBoundingClientRect()
-    let screenPosition = editor.element.screenPositionForPixelPosition({
-      top: (clientY - clientRect.top) + editor.element.getScrollTop(),
-      left: (clientX - clientRect.left) + editor.element.getScrollLeft()
-    })
+    let screenPosition = null
+    if (typeof editor.screenPositionForPixelPosition != 'undefined'){ // using new api
+      screenPosition = editor.screenPositionForPixelPosition({
+        top: (clientY - clientRect.top) + editor.element.scrollTop,
+        left: (clientX - clientRect.left) + editor.element.scrollLeft
+      })
+    } else { // must be using depricated api, see commit: https://github.com/atom/atom/commit/535a9da94657f92498f8bc7f3f27c07c779555d6
+      screenPosition = editor.element.screenPositionForPixelPosition({
+        top: (clientY - clientRect.top) + editor.element.getScrollTop(),
+        left: (clientX - clientRect.left) + editor.element.getScrollLeft()
+      })
+    }
     return editor.bufferPositionForScreenPosition(screenPosition)
   }
 


### PR DESCRIPTION
This fixes [issue 36](https://github.com/willyelm/xatom-debug/issues/36). 

I was added a workaround by adding a check to see if the function getScrollTop is defined, falling back on the old api if not. Not sure why the 'editor' passed into getEditorPositionFromEvent sometimes uses the old api, and sometimes uses the new one. This workaround accommodates both cases.

Thanks to [this comment on issue 170 at ionide](https://github.com/ionide/ionide-atom-fsharp/issues/170#issuecomment-152482797)
> You have to use editor.getScrollTop() instead of editor.displayBuffer.getScrollTop() in the definiton of bufferPositionFromMouseEvent, because getScrollTop has moved from DisplayBuffer to TextEditorElement since atom/atom@535a9da.
